### PR TITLE
fix: too long to use Feed.contentSnippet for issue title

### DIFF
--- a/src/chetsumi.ts
+++ b/src/chetsumi.ts
@@ -6,6 +6,7 @@ import { Repository } from './repository'
 
 interface Feed {
   link: string
+  title: string
   contentSnippet: string
   isoDate: string
 }
@@ -122,7 +123,7 @@ console.log('run', run)
   }
 
   protected async createIssue(feed: Feed) {
-    const title = removeHash(feed.contentSnippet)
+    const title = removeHash(feed.title)
     const body = `New updates on head repo.\r\n${feed.link}`
 
     const res = await this.github.createIssue(this.upstream, {


### PR DESCRIPTION
## Description

See https://github.com/vuejs-jp/ja.vuejs.org/issues/368

Issue を作るときに利用している `Feed.contentSnippet` は、コミットメッセージ全文を利用しています。
以下の例だと `entry.content` がすべて。
いまのままだと、Issue タイトルが長すぎる。Author の情報に含まれる個人名やメールアドレスが入ってしまう。といった問題があります。

```
<entry>
  <id>tag:github.com,2008:Grit::Commit/42bb2a2abf2a93f30094cf645e433b5ffca2744a</id>
  <link type="text/html" rel="alternate" href="https://github.com/vuejs/docs-next/commit/42bb2a2abf2a93f30094cf645e433b5ffca2744a"/>
  <title>
      The description of `this` in setup is inconsistent with the source co…
  </title>
  <updated>2021-05-27T08:09:52Z</updated>
  <media:thumbnail height="30" width="30" url="https://avatars.githubusercontent.com/u/10335230?s=30&amp;u=eea168f9c56fc71dd64303a1b2fdecf0ee76d417&amp;v=4"/>
  <author>
    <name>coderwhy</name>
    <uri>https://github.com/coderwhy</uri>
  </author>
  <content type="html">
    &lt;pre style=&#39;white-space:pre-wrap;width:81ex&#39;&gt;The description of `this` in setup is inconsistent with the source code (#1063)

* The description of `this` in setup is inconsistent with the source code

* More accurate description of `this` in the setup function

Co-authored-by: skirtle &amp;lt;65301168+skirtles-code@users.noreply.github.com&amp;gt;

* fix:Removed some formatted commas

Co-authored-by: coderwhy &amp;lt;coderwhy@gmail.com&amp;gt;
Co-authored-by: skirtle &amp;lt;65301168+skirtles-code@users.noreply.github.com&amp;gt;&lt;/pre&gt;
  </content>
</entry>
```

## Proposed Solution

`entry.title` を利用するように修正します。

## Additional Information
