### PR TITLE
feat: add the labels option

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,14 @@ jobs:
           # Ryu-Cho determines the last run by looking into last workflow
           # run timestamp. Optional. Defaults to `ryu-cho`.
           workflow-name: ryu-cho
+
+          # Labels to add to the issues. You can specify multiple labels.
+          # Each label must be separated by a newline.
+          # Optional. Defaults to empty(no labels are added).
+          labels: |
+            sync
+            needs review
+            my label
 ```
 
 The important part to note is that you must match the GitHub workflow name to `workflow-name` option.

--- a/src/config.ts
+++ b/src/config.ts
@@ -84,6 +84,17 @@ export interface UserConfig {
    * @example 'docs/'
    */
   pathStartsWith?: string
+
+  /**
+   * Labels to add to the issues. You can specify multiple labels. Each
+   * label must be separated by a newline.
+   *
+   * @default undefined
+   * @example |
+   *  label1
+   *  label2
+   */
+  labels?: string
 }
 
 export interface Config {
@@ -93,6 +104,7 @@ export interface Config {
   workflowName: string
   trackFrom: string
   pathStartsWith?: string
+  labels?: string
 
   remote: {
     upstream: Remote
@@ -115,6 +127,7 @@ export function createConfig(config: UserConfig): Config {
     workflowName: config.workflowName ?? 'ryu-cho',
     trackFrom: config.trackFrom,
     pathStartsWith: config.pathStartsWith,
+    labels: config.labels,
 
     remote: {
       upstream: {

--- a/src/github.ts
+++ b/src/github.ts
@@ -4,6 +4,7 @@ import { Remote } from './config'
 export interface CreateIssueOptions {
   title: string
   body: string
+  labels: string[]
 }
 
 export interface CreatePullRequestOptions {
@@ -38,7 +39,8 @@ export class GitHub {
       owner: remote.owner,
       repo: remote.name,
       title: options.title,
-      body: options.body
+      body: options.body,
+      labels: options.labels
     })
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,7 +19,8 @@ const config = createConfig({
   headRepoBranch: process.env.HEAD_REPO_BRANCH,
   workflowName: process.env.WORKFLOW_NAME,
   trackFrom: process.env.TRACK_FROM!,
-  pathStartsWith: process.env.PATH_STARTS_WITH
+  pathStartsWith: process.env.PATH_STARTS_WITH,
+  labels: process.env.LABELS
 })
 
 const ryuCho = new RyuCho(config)

--- a/src/ryu-cho.ts
+++ b/src/ryu-cho.ts
@@ -1,4 +1,4 @@
-import { log, extractBasename, removeHash } from './utils'
+import { log, extractBasename, removeHash, splitByNewline } from './utils'
 import { Config, Remote } from './config'
 import { Rss } from './rss'
 import { GitHub } from './github'
@@ -118,10 +118,12 @@ export class RyuCho {
   protected async createIssue(feed: Feed) {
     const title = removeHash(feed.title)
     const body = `New updates on head repo.\r\n${feed.link}`
+    const labels = splitByNewline(this.config.labels)
 
     const res = await this.github.createIssue(this.upstream, {
       title,
-      body
+      body,
+      labels
     })
 
     log('S', `Issue created: ${res.data.html_url}`)

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -47,3 +47,11 @@ export function extractRepoOwner(url: string): string {
 export function removeHash(text: string): string {
   return text.replace(/( )?\(#.*\)/, '')
 }
+
+export function splitByNewline(text: string | undefined): string[] {
+  if (!text) {
+    return []
+  }
+
+  return text.split('\n').filter((line) => line.trim() !== '')
+}

--- a/tests/utils.spec.ts
+++ b/tests/utils.spec.ts
@@ -44,4 +44,34 @@ describe('utils', () => {
         .toBe('Text which does not contain hash')
     })
   })
+
+  describe('#splitByNewline', () => {
+    it('splits the text by newline', () => {
+      const text = 'line1\nline2\nline3\nline5'
+
+      expect(Utils.splitByNewline(text)).toEqual([
+        'line1',
+        'line2',
+        'line3',
+        'line5'
+      ])
+    })
+
+    it('removes empty lines', () => {
+      const text = '\nline1\n\nline2\n\n'
+
+      expect(Utils.splitByNewline(text)).toEqual([
+        'line1',
+        'line2'
+      ])
+    })
+
+    it('returns empty array if text is empty', () => {
+      expect(Utils.splitByNewline('')).toEqual([])
+    })
+
+    it('returns empty array if text is undefined', () => {
+      expect(Utils.splitByNewline(undefined)).toEqual([])
+    })
+  })
 })


### PR DESCRIPTION
### Description

resolved #15 

### Additional context

- GitHub actions can't pass array input yet, so I've implemented the `Utils.splitByNewline` function and used it.
- To simplify the parsing logic(`Utils.splitByNewLine`), I chose the following interface - what do you think of it?
  ```yaml
  labels: |
    label1
    label2
  ```
- Let me know if I missed anything