### PR TITLE
fix: rearrange processing order

### DIFF
--- a/src/ryu-cho.ts
+++ b/src/ryu-cho.ts
@@ -42,10 +42,11 @@ export class RyuCho {
     this.repo.setup()
 
     const run = await this.getRun()
-    const feed = await this.getFeed()
+    const feed = (await this.getFeed()) as Feed[]
+    feed.sort((a, b) => (a.isoDate > b.isoDate ? 1 : -1))
 
     for (const i in feed) {
-      await this.processFeed(feed[i] as Feed, run)
+      await this.processFeed(feed[i], run)
     }
   }
 


### PR DESCRIPTION
This PR fixes the processing order, which previously started with the newest commits and now begins with the oldest ones, ensuring chronological processing.

### Screenshots Before Correction
#### 1. Upstream repo
The top is the newest. 
![image](https://github.com/vuejs-translations/ryu-cho/assets/46585162/dd93282f-f086-407d-890d-ec32a302c46c)
(https://github.com/vuejs/docs/commits/main/)

#### 2. ryu-cho log
Processed in reverse order. This may cause degradation. 
![image](https://github.com/vuejs-translations/ryu-cho/assets/46585162/c0df44a9-1df8-4cf1-bec5-dee713826f9c)
(https://github.com/vuejs-translations/docs-ja/actions/runs/8522722189/job/23343524897)

